### PR TITLE
Fix unstable RMSNorm

### DIFF
--- a/EasyLM/models/llama/llama_model.py
+++ b/EasyLM/models/llama/llama_model.py
@@ -308,7 +308,8 @@ class RMSNorm(nn.Module):
         return x * jax.lax.rsqrt(jnp.square(x).mean(-1, keepdims=True) + self.eps)
 
     def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
-        output = self._norm(x.astype(self.dtype)).astype(self.dtype)
+        x = x.astype(jnp.promote_types(self.dtype, jnp.float32))
+        output = self._norm(x).astype(self.dtype)
         weight = jnp.asarray(self.weight, self.dtype)
         return output * weight
 


### PR DESCRIPTION
As mentioned in [flax's doc](https://flax.readthedocs.io/en/latest/_modules/flax/linen/normalization.html), with fp16 training, normalization should still use fp32 for stability.
Below is what I observed in evaluating LLaMA with EasyLM. All experiments use the same sample:
`dtype=jnp.float32` or `dtype=jnp.bfloat16`: the loss is 0.12
`dtype=jnp.float16`, without this pr's fix: the loss is 2
`dtype=jnp.float16`, with this pr's fix: the loss is 0.12