### PR TITLE
fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ JAX's pjit functionality.
 
 Building on top of Hugginface's [transformers](https://huggingface.co/docs/transformers/main/en/index)
 and [datasets](https://huggingface.co/docs/datasets/index), this repo provides
-an easy to use and easy to customize codebase for training large langauge models
+an easy to use and easy to customize codebase for training large language models
 without the complexity in many other frameworks.
 
 
 EasyLM is built with JAX/Flax. By leveraging JAX's pjit utility, EasyLM is able
-to train large model that doesn't fit on a single accelerator by sharding
+to train large models that don't fit on a single accelerator by sharding
 the model weights and training data across multiple accelerators. Currently,
 EasyLM supports multiple TPU/GPU training in a single host as well as multi-host
 training on Google Cloud TPU Pods.

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,8 +35,8 @@ script to set up the TPU host.
 
 ## Modular Configuration
 EasyLM is designed to be highly modular. Typically, the training or inference
-script will combine togather various of modules to form a complete training or
-inferece process. Building on top of [MLXU](https://github.com/young-geng/mlxu),
+script will combine various modules to form a complete training or
+inference process. Building on top of [MLXU](https://github.com/young-geng/mlxu),
 EasyLM training or inference scripts can directly plug in the configuration of
 used modules into the command line flags of the script.
 
@@ -67,7 +67,7 @@ if __name__ == "__main__":
 
 By plugging in the configuration of the optimizer module into the FLAGS of the
 training script, we can directly control the optimizer module from the command
-line. For exmaple, if we want to use the AdamW optimizer with learning rate 1e-4,
+line. For example, if we want to use the AdamW optimizer with learning rate 1e-4,
 we can run the training script with the following command:
 
 ``` shell

--- a/docs/parallelism.md
+++ b/docs/parallelism.md
@@ -1,6 +1,6 @@
 # Model, Data and Fully Sharded Data Parallelism
 EasyLM supports flexible model and data parallelism for training and serving
-large language models. Specifically, EasyLM uses the PJIT feature of JAX to
+large language models. Specifically, EasyLM uses the PJIT feature of JAX
 to parallelize the computation across multiple of accelerators or multiple hosts.
 To do so, all the accelerators are first grouped into a multi-dimensional mesh,
 where each axis represents a different type of parallelism. Currently, EasyLM


### PR DESCRIPTION
Interesting work! We need something like this in [Fortuna](https://github.com/awslabs/fortuna). I've been reading up on your documentation, in particular the parallelization section. I fixed a couple of typos while reading.