### PR TITLE
Pinned fastapi version

### DIFF
--- a/scripts/gpu_environment.yml
+++ b/scripts/gpu_environment.yml
@@ -42,6 +42,6 @@ dependencies:
         - lm-eval==0.3.0
         - mlxu==0.1.11
         - pydantic
-        - fastapi
+        - fastapi==0.99.1
         - uvicorn
         - gradio


### PR DESCRIPTION
[Breaking changes](https://discuss.huggingface.co/t/why-is-my-hu-spaces-api-throwing-422-error/46343) in fastapi broke EasyLM gradio webapp server.
App server could not validate JSON, returned error code 422 on POST from client (see error below).

As per fastapi [guidance](https://fastapi.tiangolo.com/deployment/versions/#pin-your-fastapi-version), version should be pinned to prevent this in the future.

```
INFO:     Started server process [51594]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:5007 (Press CTRL+C to quit)
INFO:     127.0.0.1:33142 - "GET / HTTP/1.1" 200 OK
INFO:     127.0.0.1:33142 - "GET /info HTTP/1.1" 200 OK
INFO:     127.0.0.1:33142 - "GET /theme.css HTTP/1.1" 200 OK
INFO:     127.0.0.1:33142 - "POST /run/predict HTTP/1.1" 422 Unprocessable Entity
INFO:     ('127.0.0.1', 33152) - "WebSocket /queue/join" [accepted]
INFO:     connection open
INFO:     127.0.0.1:33162 - "POST /reset HTTP/1.1" 200 OK
```

