### PR TITLE
Fix missing backslash typo in pretrain_llama_7b.sh

### DIFF
--- a/examples/pretrain_llama_7b.sh
+++ b/examples/pretrain_llama_7b.sh
@@ -41,6 +41,6 @@ python -m EasyLM.models.llama.llama_train \
     --logger.prefix='EasyLM' \
     --logger.project="open_llama_7b" \
     --logger.output_dir="/path/to/checkpoint/dir" \
-    --logger.wandb_dir="$HOME/experiment_output/open_llama_7b"
+    --logger.wandb_dir="$HOME/experiment_output/open_llama_7b" \
 |& tee $HOME/output.txt
 


### PR DESCRIPTION
Fixes a simple typo in the pretraining example script