### PR TITLE
fix the option to support 'streaming=false'

### DIFF
--- a/EasyLM/models/llama/convert_hf_to_easylm.py
+++ b/EasyLM/models/llama/convert_hf_to_easylm.py
@@ -182,11 +182,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--streaming",
         action="store_true",
-        default=True,
+        default=False,
         help="whether is model weight saved stream format",
     )
 
     args = parser.parse_args()
+    print(args.streaming)
 
     print(f"checkpoint_dir: {args.checkpoint_dir}")
     print(f"output_file: {args.output_file}")


### PR DESCRIPTION
The original code can not support "streaming=false", resulting in the generated flax version of open_llama_7b can not be used in SecretFlow-SPU :
 OSError: Unable to convert /xxx/projects/open_llama_7b/flax_model.msgpack to Flax deserializable object
